### PR TITLE
Fix race condition in timerCtx.Err

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -3,6 +3,7 @@ package clock
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -70,12 +71,13 @@ func TestMock_WithDeadlineCancelledWithParent(t *testing.T) {
 	parent, cancel := context.WithCancel(context.Background())
 	ctx, _ := ContextWithDeadline(parent, c, c.Now().Add(time.Second))
 	cancel()
+	runtime.Gosched()
 	select {
 	case <-ctx.Done():
 		if !errors.Is(ctx.Err(), context.Canceled) {
-			t.Error("invalid type of error returned after cancellation")
+			t.Errorf("invalid type of error returned after cancellation: %v", ctx.Err())
 		}
-	case <-time.After(time.Second + delay):
+	default:
 		t.Error("context is not cancelled when parent context is cancelled")
 	}
 }


### PR DESCRIPTION
I came across a data race while using this package caused by the timerCtx.Err function ignoring the Mutex when accessing the err field, this change should resolve that